### PR TITLE
Provide better aws-adfs error messages in es-proxy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'aws-sdk-core'
+gem 'aws-sdk-ssm'
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,32 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aws-eventstream (1.1.0)
+    aws-partitions (1.412.0)
+    aws-sdk-core (3.110.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-ssm (1.101.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.2)
+      aws-eventstream (~> 1, >= 1.0.2)
+    coderay (1.1.3)
+    jmespath (1.4.0)
+    method_source (1.0.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  aws-sdk-core
+  aws-sdk-ssm
+  pry
+
+BUNDLED WITH
+   2.1.4

--- a/bin/es-proxy
+++ b/bin/es-proxy
@@ -3,27 +3,55 @@
 require 'aws-sdk-core'
 require 'aws-sdk-ssm'
 
-ENV['AWS_PROFILE'] ||= ENV['AWS_DEFAULT_PROFILE']
-credentials = Aws::SharedCredentials.new
-ssm = Aws::SSM::Client.new(credentials: credentials)
-endpoint = ssm.get_parameter(name: '/stack-donut/Settings/common_indexer/endpoint', with_decryption: true).parameter.value
-region = `aws configure get region --profile #{credentials.profile_name}`.chomp
-cmdline = [
-  'docker',
-  'run',
-  '-v',
-  "#{ENV['HOME']}/.aws:/.aws",
-  '-e',
-  "AWS_PROFILE=#{ENV['AWS_PROFILE']}",
-  '-e',
-  "AWS_REGION=#{region}",
-  '-ti',
-  '-p',
-  '9200:8080',
-  'cllunsford/aws-signing-proxy',
-  '-target',
-  endpoint
-]
-warn "Proxying http://localhost:9200/ to #{endpoint}"
-warn "Kibana available on http://localhost:9200/_plugin/kibana/"
-Kernel.system(*cmdline, out: File::NULL)
+def main
+  ENV['AWS_PROFILE'] ||= ENV['AWS_DEFAULT_PROFILE']
+  credentials = shared_credentials()
+  endpoint = elasticsearch_endpoint(credentials)
+  region = `aws configure get region --profile #{credentials.profile_name}`.chomp
+  cmdline = [
+    'docker',
+    'run',
+    '-v',
+    "#{ENV['HOME']}/.aws:/.aws",
+    '-e',
+    "AWS_PROFILE=#{ENV['AWS_PROFILE']}",
+    '-e',
+    "AWS_REGION=#{region}",
+    '-ti',
+    '-p',
+    '9200:8080',
+    'cllunsford/aws-signing-proxy',
+    '-target',
+    endpoint
+  ]
+  warn "Proxying http://localhost:9200/ to #{endpoint}"
+  warn "Kibana available on http://localhost:9200/_plugin/kibana/"
+  Kernel.system(*cmdline, out: File::NULL)
+end
+
+def elasticsearch_endpoint(credentials)
+  ssm = Aws::SSM::Client.new(credentials: credentials)
+  ssm.get_parameter(name: '/stack-donut/Settings/common_indexer/endpoint', with_decryption: true).parameter.value
+rescue Aws::SSM::Errors::ExpiredTokenException
+  aws_session_error(credentials, 'AWS session token for profile %s is expired.')
+end
+
+def shared_credentials
+  Aws::SharedCredentials.new.tap do |credentials|
+    if credentials.credentials.nil?
+      aws_session_error(credentials, 'AWS Credentials not found for profile %s.') 
+    end
+  end
+end
+
+def aws_session_error(credentials, error_string)
+  profile = credentials.profile_name
+  $stderr.puts <<~__EOC__
+  #{error_string % profile} Please run the following command and try again:
+
+      aws-adfs login --adfs-host=ads-fed.northwestern.edu --profile=#{profile}
+  __EOC__
+  exit(128)
+end
+
+main()


### PR DESCRIPTION
### Missing Credentials

```
➜ es-proxy
AWS Credentials not found for profile staging. Please run the following command and try again:

    aws-adfs login --adfs-host=ads-fed.northwestern.edu --profile=staging
```

### Expired Credentials

```
➜ es-proxy
AWS session token for profile staging is expired. Please run the following command and try again:

    aws-adfs login --adfs-host=ads-fed.northwestern.edu --profile=staging
```
