### PR TITLE
Support better NodeJS version management via asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+terraform 1.1.5

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ all of the same subcommands, parameters, and arguments, with a few notable enhan
 
 ### Cheat Sheet
 
+#### `devstack` Commands
+
 * `devstack -t [rest-of-command]` will run `devstack` in test mode. That means:
   * All services run on test ports instead of dev ports (e.g., `solr` on `8985` instead of `8983`)
   * The `COMPOSE_PROJECT_NAME` will have `_test` appended (e.g., the default container names will be 
@@ -39,9 +41,42 @@ all of the same subcommands, parameters, and arguments, with a few notable enhan
   all running services). `-f` behaves the way it does for the `tail` command.
 * `devstack down [-v]`: Bring down the stack. Adding `-v` will destroy the stack's persistent data volumes as
   well, resulting in a clean slate on the next `up`.
+* `devstack provision [APPLICATION]`: Use terraform to provision `localstack` for the specified application.
 * `devstack ps`: View the current state of running containers
 * `devstack update`: Upgrade to the latest revision of `devstack`
-* `source $(devstack utils)`: Install additional devstack utility functions in the current shell (best to add this command to `~/.bashrc` or `~/.zshrc`)
+* `devstack branch [BRANCH]`: Switch devstack to `BRANCH` (for development and testing). If `BRANCH` is not 
+  specified, list existing branches.
+* `source $(devstack utils)`: Install additional devstack utility functions in the current shell
+
+#### Other Utilities and Functions
+
+##### Tool Management
+
+* `asdf-install-plugins`: Install all plugins needed for the current working directory's application 
+  environment
+* `asdf-install-npm`: Install the correct `npm` version for the current working directory's application
+  environment
+
+##### Remote Service Access
+
+* `es-proxy`: Run an Elasticsearch proxy to access the staging or production index, as well as a Kibana front-end
+* `ecr-login`: Log into the AWS-hosted Docker repository (Elastic Container Repository) using profile credentials
+* `ecr-push [IMAGE] [NAME]`: Push a local Docker image to the ECR repository as `NAME`
+* `ecs-exec [SERVICE]`: Attach to a running AWS service container. Valid values for `SERVICE` are:
+  * `arch-webapp`
+  * `arch-worker`
+  * `avr-weball`
+  * `avr-worker`
+  * `fcrepo`
+  * `meadow`
+  * `solr`
+  * `zookeeper`
+
+##### Convenience Scripts
+
+* `awslocal`: Command wrapper to run `aws` CLI commands against the running localstack container
+* `tfselect [ENVIRONMENT]`: Set `AWS_PROFILE`, log in, and switch the current Terraform
+  workspace to `ENVIRONMENT`.
 
 ### Tips and Tricks
 

--- a/bin/devstack
+++ b/bin/devstack
@@ -85,7 +85,9 @@ class DevStack
   def display_usage
     output = `#{docker_compose_cmd} 2>&1`.split(/\nCommands:\n/).last
     commands = Hash[output.lines.collect { |line| line.strip.split(/\s+/, 2) }.reject(&:empty?)]
+    commands['branch'] = 'Show or change the current devstack working tree branch (for development)'
     commands['portmap'] = 'Get a JSON report of running services and their ports'
+    commands['provision'] = 'Use terraform to provision `localstack` for the specified application'
     commands['update'] = 'Pull the latest devstack command/configs from github'
     commands['utils'] = 'Show the path to the devstack bash/zsh shell functions'
     commands['version'] = 'Show the devstack version information'
@@ -261,6 +263,21 @@ class DevStack
     end
   end
 
+  def branch!
+    Dir.chdir(root.to_s) do
+      `git fetch origin`
+      if context.argz[0]
+        if `git status --porcelain`.empty?
+          system("git switch #{context.argz[0]}")
+        else
+          warn "Cannot switch branches. Current working tree is not clean."
+        end
+      else
+        system("git branch")
+      end
+    end
+  end
+
   def update!
     Dir.chdir(root.to_s) do
       `git pull origin`
@@ -279,6 +296,8 @@ class DevStack
     case context.argv.first
     when 'version', '-v', '--version'
       display_version
+    when 'branch'
+      branch!
     when 'link'
       link!
     when 'portmap'

--- a/devstack-functions
+++ b/devstack-functions
@@ -64,3 +64,40 @@ function tfselect() {
 function awslocal() {
   aws --endpoint https://localhost.localstack.cloud:4566/ $@
 }
+
+function asdf-install-npm() {
+  tool_files=$(asdf-tool-versions)
+  node_versions=$(cat $(echo $tool_files) | grep nodejs | awk '{print $2}' | sort -u)
+  npm_versions=$(cat $(echo $tool_files) | grep npm | awk '{print $2}' | sort -u)
+  for nodejs in $(echo $node_versions); do 
+    for npm in $(echo $npm_versions); do
+      echo "Installing npm v${npm} for NodeJS v${nodejs}"
+      ASDF_NODEJS_VERSION=${nodejs} npm install -g npm@${npm};
+    done
+  done  
+}
+
+function asdf-install-plugins() {
+  tool_files=$(asdf-tool-versions)
+  plugins=$(cat $(echo $tool_files) | awk '{print $1}' | grep -v '#' | sort -u)
+  for plugin in $(echo $plugins); do
+    asdf plugin add $plugin
+  done
+}
+
+function asdf-tool-versions() {
+  result=""
+  if [ -e ./.tool-versions ]; then
+    result="${result} ${PWD}/.tool-versions"
+  fi
+
+  original_dir=$PWD
+  while [ $PWD != "/" ]; do
+    cd ..
+    if [ -e ./.tool-versions ]; then
+      result="${result} ${PWD}/.tool-versions"
+    fi
+  done
+  cd $original_dir
+  echo $result | xargs
+}

--- a/extras/localstack/terraform/modules/localstack_lambda/patchaws
+++ b/extras/localstack/terraform/modules/localstack_lambda/patchaws
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+ASDF_NODEJS_VERSION=$(asdf list nodejs | grep ' 14.' | sort -r | head -1 | xargs)
+
 if [ -f node_modules/aws-sdk/lib/_aws.js ]; then
   exit 0
 fi


### PR DESCRIPTION
- Always use nodejs v14.x to install lambdas in localstack
- Add functions to manage npm versions
- Add `devstack branch` subcommand to assist with development and testing
- Update README documentation