### PR TITLE
Migrate to OpenSearch and OpenSearch Dashboard from Elasticsearch and Kibana

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -60,7 +60,7 @@ services:
       retries: 3
   elasticproxy:
     depends_on:
-    - elasticsearch
+    - opensearch
     image: nulib/elasticproxy:latest
     restart: unless-stopped
     read_only: true
@@ -76,7 +76,7 @@ services:
     ports:
     - 3335:3334
     environment:
-      UPSTREAM: http://elasticsearch:9200/
+      UPSTREAM: http://opensearch:9200/
       API_TOKEN_HEADER: X-Api-Token
       API_TOKEN_SECRET: ab00ffc725da64fa07b20f42ed8bbcf0fda5779aa55c90cedf3a81e09e3a2b14
       OPENAM_SERVER: https://websso.it.northwestern.edu/amserver/
@@ -92,26 +92,25 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
-  elasticsearch:
-    image: bitnami/elasticsearch:6.8.14
+  opensearch:
+    image: opensearchproject/opensearch:1.3.1
     restart: unless-stopped
-    read_only: true
+    read_only: false
     volumes:
     - type: volume
-      target: /bitnami/elasticsearch/data
+      target: /usr/share/opensearch/data
     - type: volume
       target: /tmp
     - type: volume
-      target: /opt/bitnami/elasticsearch
-    - type: volume
-      target: /var/log
-    - type: volume
-      target: /var/run
-    - ./extras/elasticsearch/elasticsearch.yml:/opt/bitnami/elasticsearch/config/elasticsearch.yml
+      target: /usr/share/opensearch/logs
     ports:
     - 9202:9200
     environment:
-      ELASTICSEARCH_HEAP_SIZE: "256m"
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx1024m"
+      - "DISABLE_INSTALL_DEMO_CONFIG=true"
+      - "DISABLE_SECURITY_PLUGIN=true"
+      - discovery.type=single-node
     ulimits:
       memlock:
         soft: -1
@@ -151,13 +150,13 @@ services:
     - AVALON_STREAMING_BUCKET_URL=http://localstack:4566/derivatives/
     ports:
     - '8881:80'
-  kibana:
-    depends_on:
-    - elasticsearch
-    image: docker.elastic.co/kibana/kibana-oss:6.3.2
-    restart: unless-stopped
+  opensearch-dashboard:
+    image: opensearchproject/opensearch-dashboards:1.3.0
     ports:
-    - 5603:5601
+      - 5603:5601
+    environment:
+      - 'OPENSEARCH_HOSTS=["http://opensearch:9200"]'
+      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"
     healthcheck:
       test:
       - CMD
@@ -205,6 +204,7 @@ services:
     ports:
       - 4568:4566
     environment:
+      DISABLE_CORS_CHECKS: 1
       DNS_ADDRESS: 127.0.0.1
       EDGE_PORT: 4566
       EDGE_PORT_HTTP: 4566

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.4'
 volumes:
   fedora:
   db:
-  es:
+  opensearch:
   ldap:
   localstack:
   solr:
@@ -75,7 +75,7 @@ services:
       retries: 3
   elasticproxy:
     depends_on:
-    - elasticsearch
+    - opensearch
     image: nulib/elasticproxy:latest
     restart: unless-stopped
     read_only: true
@@ -97,7 +97,7 @@ services:
     ports:
     - 3334:3334
     environment:
-      UPSTREAM: http://elasticsearch:9200/
+      UPSTREAM: http://opensearch:9200/
       AWS_ACCESS_KEY_ID: fake_key_id
       AWS_SECRET_ACCESS_KEY: fake_access_key
       API_TOKEN_HEADER: X-Api-Token
@@ -116,27 +116,26 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
-  elasticsearch:
-    image: bitnami/elasticsearch:6.8.14
+  opensearch:
+    image: opensearchproject/opensearch:1.3.1
     restart: unless-stopped
-    read_only: true
+    read_only: false
     volumes:
     - type: volume
-      source: es
-      target: /bitnami/elasticsearch/data
+      source: opensearch
+      target: /usr/share/opensearch/data
     - type: volume
       target: /tmp
     - type: volume
-      target: /opt/bitnami/elasticsearch
-    - type: volume
-      target: /var/log
-    - type: volume
-      target: /var/run
-    - ./extras/elasticsearch/elasticsearch.yml:/opt/bitnami/elasticsearch/config/elasticsearch.yml
+      target: /usr/share/opensearch/logs
     ports:
     - 9201:9200
     environment:
-      ELASTICSEARCH_HEAP_SIZE: "256m"
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx1024m"
+      - "DISABLE_INSTALL_DEMO_CONFIG=true"
+      - "DISABLE_SECURITY_PLUGIN=true"
+      - discovery.type=single-node
     ulimits:
       memlock:
         soft: -1
@@ -177,13 +176,13 @@ services:
     - AVALON_STREAMING_BUCKET_URL=https://devbox.library.northwestern.edu:4566/derivatives/
     ports:
     - '8880:80'
-  kibana:
-    depends_on:
-    - elasticsearch
-    image: docker.elastic.co/kibana/kibana-oss:6.3.2
-    restart: unless-stopped
+  opensearch-dashboard:
+    image: opensearchproject/opensearch-dashboards:1.3.0
     ports:
-    - 5602:5601
+      - 5602:5601
+    environment:
+      - 'OPENSEARCH_HOSTS=["http://opensearch:9200"]'
+      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"
     healthcheck:
       test:
       - CMD
@@ -238,6 +237,7 @@ services:
     environment:
       DATA_DIR: /data
       DEBUG: ${LOCALSTACK_DEBUG:-}
+      DISABLE_CORS_CHECKS: 1
       DNS_ADDRESS: 127.0.0.1
       DOCKER_HOST: unix:///var/run/docker.sock
       EDGE_PORT: 4566

--- a/sets.yml
+++ b/sets.yml
@@ -19,7 +19,7 @@ arch:
 dc: &dc
   services:
     - elasticproxy
-    - elasticsearch
+    - opensearch
     - iiif
     - kibana
     - localstack
@@ -28,7 +28,7 @@ fen: *dc
 meadow:
   services:
     - db
-    - elasticsearch
+    - opensearch
     - iiif
     - ldap
     - localstack


### PR DESCRIPTION
Same as before, running `devstack up meadow` will spin up an `OpenSearch` container and explicitly add `devstack up meadow opensearch-dashboard` to spin up the `OpenSearch Dashboard` container.