### PR TITLE
Make devstack work like AWS dev environment for now

### DIFF
--- a/bin/devstack
+++ b/bin/devstack
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'erb'
 require 'fileutils'
 require 'json'
 require 'pathname'
@@ -280,12 +281,19 @@ class DevStack
       FileUtils.cp(root.join("extras/localstack/terraform/#{manifest}.tf"), tf_dir)
     end
 
+    %w(dev test).each do |environment|
+      File.open(File.join(tf_dir, "#{environment}.tfvars"), 'w') do |var_file|
+        template = ERB.new(File.read("extras/localstack/terraform/#{environment}.tfvars"))
+        var_file.write(template.result(binding))
+      end
+    end
+
     Dir.chdir(tf_dir) do
       workspace = @context.test_mode ? 'test' : 'dev'
       action = %x(terraform workspace list) =~ /\b#{workspace}\b/ ? 'select' : 'new'
       system("terraform init -upgrade")
       system("terraform workspace #{action} #{workspace}")
-      system("terraform apply -auto-approve -var localstack_endpoint=https://localhost.localstack.cloud:#{port}")
+      system("terraform apply -auto-approve -var-file #{workspace}.tfvars -var localstack_endpoint=https://localhost.localstack.cloud:#{port}")
     end
   end
 

--- a/extras/localstack/terraform/dev.tfvars
+++ b/extras/localstack/terraform/dev.tfvars
@@ -1,0 +1,34 @@
+config_secrets = {
+  dc = {
+    base_url    = "https://fen.rdc-staging.library.northwestern.edu/"
+  }
+  ezid = {
+    password    = "apitest"
+    shoulder    = "ark:/99999/fk4"
+    user        = "apitest"
+  }
+
+  geonames = {
+    username    = "<%= ENV['GEONAMES_USERNAME'] %>"
+  }
+
+  nusso = {
+    api_key     = "<%= ENV['NUSSO_API_KEY'] %>"
+    base_url    = "https://northwestern-test.apigee.net/agentless-websso/"
+  }
+
+}
+
+user_secrets = {
+  iiif = {
+    base_url     = "https://devbox.library.northwestern.edu:8183/iiif/2/"
+    manifest_url = "https://dev-pyramids.s3.localhost.localstack.cloud:4566/public/"
+  }
+  
+  streaming = {
+    base_url    = "https://dev-streaming.s3.localhost.localstack.cloud:4566/"
+  }
+}
+
+ssl_certificate_file    = "/usr/local/etc/devbox_ssl/devbox.library.full.pem"
+ssl_key_file            = "/usr/local/etc/devbox_ssl/devbox.library.key.pem"

--- a/extras/localstack/terraform/environment_config.tf
+++ b/extras/localstack/terraform/environment_config.tf
@@ -1,0 +1,82 @@
+locals {
+  project       = "meadow"
+  port_offset   = terraform.workspace == "test" ? 2 : 1
+}
+
+resource "aws_secretsmanager_secret" "db_secrets" {
+  name    = "${local.project}/db"
+  description = "Database configuration secrets"
+}
+
+resource "aws_secretsmanager_secret" "index_secrets" {
+  name    = "${local.project}/index"
+  description = "OpenSearch index secrets"
+}
+
+resource "aws_secretsmanager_secret" "ldap_secrets" {
+  name    = "${local.project}/ldap"
+  description = "LDAP server secrets"
+}
+
+resource "aws_secretsmanager_secret" "config_secrets" {
+  name    = "${local.project}/config"
+  description = "Miscellaneous configuration secrets"
+}
+
+resource "aws_secretsmanager_secret" "user_secrets" {
+  name    = "${local.project}/config/${terraform.workspace}"
+  description = "User-specific configuration secrets"
+}
+
+resource "aws_secretsmanager_secret" "ssl_certificate" {
+  name = "${local.project}/ssl"
+  description = "Wildcard SSL certificate and private key"
+}
+
+resource "aws_secretsmanager_secret_version" "db_secrets" {
+  secret_id = aws_secretsmanager_secret.db_secrets.id
+  secret_string = jsonencode({
+    host        = "localhost"
+    port        = 5432 + local.port_offset
+    user        = "docker"
+    password    = "d0ck3r"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "index_secrets" {
+  secret_id = aws_secretsmanager_secret.index_secrets.id
+  secret_string = jsonencode({
+    index_endpoint    = "http://localhost:${9200 + local.port_offset}"
+    kibana_endpoint   = "http://localhost:${5601 + local.port_offset}"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "ldap_secrets" {
+  secret_id = aws_secretsmanager_secret.ldap_secrets.id
+  secret_string = jsonencode({
+    host       = "localhost"
+    base       = "DC=library,DC=northwestern,DC=edu"
+    port       = 389 + local.port_offset
+    user_dn    = "cn=Administrator,cn=Users,dc=library,dc=northwestern,dc=edu"
+    password   = "d0ck3rAdm1n!"
+    ssl        = "false"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "config_secrets" {
+  secret_id = aws_secretsmanager_secret.config_secrets.id
+  secret_string = jsonencode(var.config_secrets)
+}
+
+resource "aws_secretsmanager_secret_version" "user_secrets" {
+  secret_id = aws_secretsmanager_secret.user_secrets.id
+  secret_string = jsonencode(var.user_secrets)
+}
+
+resource "aws_secretsmanager_secret_version" "ssl_certificate" {
+  secret_id       = aws_secretsmanager_secret.ssl_certificate.id
+  secret_string   = jsonencode({
+    certificate = file(var.ssl_certificate_file)
+    key         = file(var.ssl_key_file)
+  })
+}

--- a/extras/localstack/terraform/test.tfvars
+++ b/extras/localstack/terraform/test.tfvars
@@ -1,0 +1,30 @@
+config_secrets = {
+  ezid = {
+    password    = "apitest"
+    shoulder    = "ark:/99999/fk4"
+    user        = "apitest"
+  }
+
+  geonames = {
+    username    = "<%= ENV['GEONAMES_USERNAME'] %>"
+  }
+
+  nusso = {
+    api_key     = "test-sso-key"
+    base_url    = "https://northwestern-dev.apigee.net/agentless-websso/"
+  }
+
+}
+
+user_secrets = {
+  iiif = {
+    manifest_url = "http://test-pyramids.s3.localhost.localstack.cloud:4568/public/"
+  }
+
+  streaming = {
+    base_url    = "https://test-streaming-url/"
+  }
+}
+
+ssl_certificate_file    = "/dev/null"
+ssl_key_file            = "/dev/null"

--- a/extras/localstack/terraform/variables.tf
+++ b/extras/localstack/terraform/variables.tf
@@ -1,0 +1,24 @@
+variable "config_secrets" {
+  type    = map(map(string))
+  default = {}
+}
+
+variable "ssl_certificate_file" {
+  type    = string
+  default = "../../miscellany/devbox_cert/dev.rdc.wildcard.full.pem"
+}
+
+variable "ssl_key_file" {
+  type    = string
+  default = "../../miscellany/devbox_cert/dev.rdc.wildcard.key.pem"
+}
+
+variable "test_mode" {
+  type    = bool
+  default = false
+}
+
+variable "user_secrets" {
+  type    = map(map(string))
+  default = {}
+}

--- a/sets.yml
+++ b/sets.yml
@@ -34,3 +34,5 @@ meadow:
     - localstack
   resources:
     - digester
+    - environment_config
+    - variables


### PR DESCRIPTION
Add Secrets Manager secrets to localstack to allow Meadow to continue to run locally the way it does in the AWS dev environment. This is a fully backwards compatible change.